### PR TITLE
Remove the beta download link

### DIFF
--- a/src/resources/public/js/syslog-ng.org.js
+++ b/src/resources/public/js/syslog-ng.org.js
@@ -24,5 +24,4 @@ $(document).ready(function () {
 
   get_latest_release("syslog-ng", false);
   get_latest_release("syslog-ng-incubator", false);
-  get_latest_release("syslog-ng", true, "syslog--ng%20BETA", "syslog-ng-beta", "F7841E");
 });

--- a/src/syslog_ng/org/parts/getting_started.clj
+++ b/src/syslog_ng/org/parts/getting_started.clj
@@ -48,9 +48,4 @@ log                  { source(s_system); destination(d_all); };"]
         [:a {:href "https://github.com/balabit/syslog-ng-incubator/releases/latest"
              :id "release-syslog-ng-incubator"}
          [:img {:src
-                "//img.shields.io/badge/syslog--ng--incubator-latest-246EAB.svg?style=flat"}]]]
-       [:li
-        [:a {:href "https://github.com/balabit/syslog-ng/releases"
-             :id "release-syslog-ng-beta"}
-         [:img {:src
-                "//img.shields.io/badge/syslog--ng%20BETA-latest-F7841E.svg?style=flat"}]]]]]]]))
+                "//img.shields.io/badge/syslog--ng--incubator-latest-246EAB.svg?style=flat"}]]]]]]]))


### PR DESCRIPTION
With syslog-ng 3.6.1 out, the BETA link is irrelevant. Removing the link and the JavaScript that updated it fixes #17.
